### PR TITLE
Spelling error in `testnames` program argument for Eclipse staging tests launch configuration #6826

### DIFF
--- a/.launches/Staging tests.launch.xml
+++ b/.launches/Staging tests.launch.xml
@@ -5,7 +5,7 @@
 </listAttribute>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.testng.remote.RemoteTestNG"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-testnames sequential-ui-tests,parallel-ui-tests,occassional-tests"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-testnames sequential-ui-tests,parallel-ui-tests,occasional-tests"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="${project.name}"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Duser.timezone=UTC -Xss2m"/>
 <mapAttribute key="org.testng.eclipse.ALL_CLASS_METHODS"/>


### PR DESCRIPTION

Fixes #6826
I changed the spelling of occassional to occasional (with one 's' instead of two).


